### PR TITLE
The Rakefile example in README.md needs updates to match with RubyMotion 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add `MotionBundler.setup` at the end of your `Rakefile`:
 
     # -*- coding: utf-8 -*-
     $:.unshift "/Library/RubyMotion/lib"
-    require "motion/project"
+    require "motion/project/template/ios"
 
     # Require and prepare Bundler
     require "bundler"


### PR DESCRIPTION
Changed the first require statement in the Rakefile example to match with  RubyMotion 2.x
