### PR TITLE
Removing the load method override for the Object class, using motion_load instead.

### DIFF
--- a/lib/motion-bundler/device/core_ext.rb
+++ b/lib/motion-bundler/device/core_ext.rb
@@ -16,7 +16,7 @@ class Object
   end
   def require_relative(string)
   end
-  def load(filename, wrap=false)
+  def motion_load(filename, wrap=false)
   end
 end
 

--- a/lib/motion-bundler/simulator/core_ext.rb
+++ b/lib/motion-bundler/simulator/core_ext.rb
@@ -13,7 +13,7 @@ class Object
   def require_relative(string)
     console.warn { require_relative string }
   end
-  def load(filename, wrap=false)
+  def motion_load(filename, wrap=false)
     console.warn { load filename }
   end
   alias :original_instance_eval :instance_eval

--- a/test/unit/simulator/test_core_ext.rb
+++ b/test/unit/simulator/test_core_ext.rb
@@ -23,12 +23,12 @@ module Unit
 
             require "foo"
             require_relative "foo/bar"
-            load "foo/baz"
+            motion_load "foo/baz"
             autoload :Qux, "foo/qux"
 
             Unit.require "foo"
             Unit.require_relative "foo/bar"
-            Unit.load "foo/baz"
+            Unit.motion_load "foo/baz"
             Unit.autoload :Qux, "foo/qux"
 
             TestCoreExt.class_eval "def foo; end"


### PR DESCRIPTION
Could it be this simple? or is it just a very naive hack for issue #1 

Tested it in a couple of apps, iOS and OS X, and it is working fine.
